### PR TITLE
Fix changed favicon url

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-const FAVICON_URL = "https://www.notion.so/images/favicon.ico";
+const FAVICON_URL = "https://www.notion.so/front-static/favicon.ico";
 
 const getFaviconDomEl = () => document.querySelector("link[rel~='icon']");
 


### PR DESCRIPTION
I have the plugin installed but for some time now it is not working anymore. I only get the default "world" favicon.

After investigating a bit, it seems like the favicon of notion has a new URL now.